### PR TITLE
use same style as mainline tags page

### DIFF
--- a/tags.tpl
+++ b/tags.tpl
@@ -8,7 +8,8 @@
     <table class="tagLetterContent">
       {foreach from=$tag_group.tags item=tag}
       <tr class="tagLine">
-        <td><a href="{$tag.URL}" title="{$tag.name}">{$tag.name}</a> [{$tag.counter}]</td>
+        <td><a href="{$tag.URL}" title="{$tag.name}">{$tag.name}</a></td>
+        <td class="nbEntries">{$tag.counter|@translate_dec:'%d photo':'%d photos'}</td>
       </tr>
       {/foreach}
     </table>


### PR DESCRIPTION
I noticed that the tag groups page showed the number of matching photos as "[n]" whereas the mainline shows "n photos" in a separate table cell - which I think looks nicer.

Not sure if that was deliberate or bit rot, here's a PR for fixing that if you want.